### PR TITLE
Fix YOLO model typing in optimizer

### DIFF
--- a/src/training/optimize_yolo.py
+++ b/src/training/optimize_yolo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, cast
 
 import torch
 from torch.nn.utils import prune
@@ -95,7 +95,7 @@ def main(weights: Path, output: Path, *, prune_pct: float = 0.2,
          quantization: str = "dynamic", steps: int = 100) -> None:
     """Load YOLO weights, prune, quantize and save."""
     yolo = YOLO(str(weights))
-    core = yolo.model  # nn.Module
+    core = cast(torch.nn.Module, yolo.model)
     apply_global_pruning(core, amount=prune_pct)
 
     if quantization == "dynamic":


### PR DESCRIPTION
## Summary
- fix typing on `yolo.model` in optimizer script so mypy & pylance are happy

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_688a24ff7478832997812a19d9d3c71b